### PR TITLE
Change the link of libtbx

### DIFF
--- a/focus/focus_build_script.sh
+++ b/focus/focus_build_script.sh
@@ -4,12 +4,13 @@ scons_ver="2.4.1"
 scons="scons-$scons_ver"
 fftw="fftw-3.3.2"
 # New versions of libtbx break compilation of FOCUS, because boost cannot be found
-libtbxrev=20000 
+libtbxrev=20000
 
 if [ ! -d libtbx ];
 then
 	# download libtbx
-	svn co https://cctbx.svn.sourceforge.net/svnroot/cctbx/trunk/libtbx libtbx --non-interactive --trust-server-cert -r$libtbxrev
+	# svn co https://cctbx.svn.sourceforge.net/svnroot/cctbx/trunk/libtbx libtbx --non-interactive --trust-server-cert -r$libtbxrev
+    svn co https://github.com/cctbx/cctbx_project/trunk/libtbx libtbx --non-interactive --trust-server-cert -r$libtbxrev
 fi
 
 if [ ! -d scons ];
@@ -18,7 +19,7 @@ then
 	curl -Lo $scons.tar.gz http://sourceforge.net/projects/scons/files/scons/$scons_ver/$scons.tar.gz/download
 	tar -xvf $scons.tar.gz
 	rm -rf $scons.tar.gz
-	
+
 	mv $scons scons
 fi
 
@@ -29,16 +30,16 @@ if [ ! -f ./base/bin/fftwf-wisdom ];
 then
 	# download and build fftw
 	prefix=`pwd`
-	
+
 	curl -o $fftw.tar.gz http://www.fftw.org/$fftw.tar.gz
 	tar -xvf $fftw.tar.gz
-	
+
 	cd $fftw
 	./configure --prefix="$prefix/base" --enable-single
-	
+
 	make $*
 	make install
-	
+
 	cd $prefix
 	rm -rf $fftw
 	rm -rf $fftw.tar.gz


### PR DESCRIPTION
Hi,

Thank you for maintaining this amazing software.
Since https://cctbx.svn.sourceforge.net seems to be no longer available, I changed the link to download libtbx.
The compilation was successful in my environment (Ubuntu 16.04) using the latest version of libtbx.
Hope this helps!

Regards,

Koki